### PR TITLE
Added directory "/etc/monit/conf.d/" for included configuration files

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,4 +25,10 @@ template "/etc/monit/monitrc" do
   notifies :restart, resources(:service => "monit"), :immediate
 end
 
-
+directory "/etc/monit/conf.d/" do
+  owner  'root'
+  group 'root'
+  mode 0755
+  action :create
+  recursive true
+end


### PR DESCRIPTION
The provided `monitrc()` method creates service-specific files in `/etc/monit/conf.d/`,
but the cookbook does not setup this directory.

Thus, the user would have to create this directory manually -- I think the cookbook should take care of that?

I'm experiencing this issue when preparing article on using the https://github.com/karmi/cookbook-elasticsearch cookbook.
