### PR TITLE
Additional configuration options as Chef attributes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,1 +1,39 @@
-README.md
+# Overview #
+Chef cookbook for the [monit](http://mmonit.com/monit/) monitoring and
+management tool.
+
+# How to add to your cookbook repository #
+
+## Download the tarball ##
+It's up on the opscode
+[cookbook community](http://community.opscode.com/cookbooks/monit) site.
+
+## Vendor via knife ##
+
+    $ knife cookbook site download monit
+
+## Track upstream changes via git ##
+I use git submodules for my chef repos so I can push/pull changes with minimal
+hassle.
+
+For more info, check out the [Pro Git](http://progit.org/book/ch6-6.html) book.
+
+#### Add the monit repo ####
+
+    $ cd YOUR_REPO_ROOT
+    $ git submodule add git://github.com/apsoto/monit.git cookbooks/monit
+
+
+History
+=======
+
+version 0.7
+-----------
+ * create /etc/monit/conf.d.  Thanks Karel Minarik (https://github.com/karmi)
+
+version 0.6
+-----------
+ * Released to github
+ * Defaults no alert on ACTION event.
+   When you manually stop/start a service, alerting me about what I just did isn't useful.
+

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,10 @@
-default[:monit][:notify_email]          = "notify@example.com"
+default[:monit][:notify][:enable]       = false
+default[:monit][:notify][:email]        = "notify@example.com"
+
+default[:monit][:httpd][:enable]        = false
+default[:monit][:httpd][:port]          = 3737
+default[:monit][:httpd][:address]       = localhost
+default[:monit][:httpd][:allow]         = %w{localhost}
 
 default[:monit][:poll_period]           = 60
 default[:monit][:poll_start_delay]      = 120
@@ -10,4 +16,3 @@ Monit $ACTION $SERVICE at $DATE on $HOST: $DESCRIPTION.
 Yours sincerely,
 monit
 EOS
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,18 +1,24 @@
+default[:monit][:logfile]               = "syslog facility log_daemon"
+
 default[:monit][:notify][:enable]       = false
 default[:monit][:notify][:email]        = "notify@example.com"
 
 default[:monit][:httpd][:enable]        = false
 default[:monit][:httpd][:port]          = 3737
-default[:monit][:httpd][:address]       = localhost
+default[:monit][:httpd][:address]       = "localhost"
 default[:monit][:httpd][:allow]         = %w{localhost}
 
 default[:monit][:poll_period]           = 60
 default[:monit][:poll_start_delay]      = 120
 
-default[:monit][:mail_format][:subject] = "$SERVICE $EVENT"
-default[:monit][:mail_format][:from]    = "monit@example.com"
-default[:monit][:mail_format][:message]    = <<-EOS
+default[:monit][:mail][:server]           = "localhost"
+default[:monit][:mail][:format][:subject] = "$SERVICE $EVENT"
+default[:monit][:mail][:format][:from]    = "monit@example.com"
+default[:monit][:mail][:format][:message]    = <<-EOS
 Monit $ACTION $SERVICE at $DATE on $HOST: $DESCRIPTION.
 Yours sincerely,
 monit
 EOS
+
+default[:monit][:queue][:location]      = "/var/monit"  # base directory where events will be stored
+default[:monit][:queue][:slots]         = nil           # limit the size of the queue

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -15,11 +15,20 @@ set mail-format {
   message: <%= @node[:monit][:mail_format][:message] %>
 }
 
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
+<% if @node[:monit][:notify][:enable] %>
+set alert <%= @node[:monit][:notify][:email] %> NOT ON { action, instance, pid, ppid }
+<% end %>
 
-set httpd port 3737 and
-    use address localhost
-    allow localhost
+<% if @node[:monit][:httpd][:enable] %>
+set httpd port <%= @node[:monit][:httpd][:port] and
+    <% unless @node[:monit][:httpd][:address].nil? %>
+    use address <%= @node[:monit][:httpd][:address] %>
+    <% end %>
+    <% unless @node[:monit][:httpd][:allow].nil> %>
+        <% @node[:monit][:httpd][:allow].each do |allow| %>
+        allow <%= allow %>
+        <% end %>
+    <% end %>
+<% end %>
 
 include /etc/monit/conf.d/*.conf
-

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -1,19 +1,24 @@
 set daemon <%= @node[:monit][:poll_period] %>
   with start delay <%= @node[:monit][:poll_start_delay] %>
 
-set logfile syslog facility log_daemon
-
-set mailserver localhost
+<% unless @node[:monit][:logfile].nil? %>
+set logfile <%= @node[:monit][:logfile] %>
+<% end %>
 
 set eventqueue
-    basedir /var/monit  # set the base directory where events will be stored
-#    slots 1000          # optionaly limit the queue size
+    basedir <%= @node[:monit][:queue][:location]  # set the base directory where events will be stored
+    <% unless @node[:monit][:queue][:slots].nil? %>
+    slots <%= @node[:monit][:queue][:slots] # optionally limit the queue size
+    <% end %>
 
+<% unless @node[:monit][:mail][:server].nil?
+set mailserver <%= @node[:monit][:mail][:server] %>
 set mail-format { 
-  from: <%= @node[:monit][:mail_format][:from] %>
-  subject: <%= @node[:monit][:mail_format][:subject] %>
-  message: <%= @node[:monit][:mail_format][:message] %>
+  from: <%= @node[:monit][:mail][:format][:from] %>
+  subject: <%= @node[:monit][:mail][:format][:subject] %>
+  message: <%= @node[:monit][:mail][:format][:message] %>
 }
+<% end %>
 
 <% if @node[:monit][:notify][:enable] %>
 set alert <%= @node[:monit][:notify][:email] %> NOT ON { action, instance, pid, ppid }


### PR DESCRIPTION
This extracts a bunch of the configuration options in monitrc into Chef attributes that can be overridden.
