### PR TITLE
Multi platform

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,9 @@ Yours sincerely,
 monit
 EOS
 
+case node['platform']
+  when "centos", "redhat", "fedora"
+    default[:monit][:include_dir] = '/etc/monit.d'
+  else
+    default[:monit][:include_dir] = '/etc/monit/conf.d'
+end

--- a/files/debian/monit.default
+++ b/files/debian/monit.default
@@ -1,0 +1,11 @@
+# Defaults for monit initscript
+# sourced by /etc/init.d/monit
+# installed at /etc/default/monit by chef
+
+# You must set this variable to for monit to start
+startup=1
+
+# To change the intervals which monit should run,
+# edit the configuration file /etc/monit/monitrc
+# It can no longer be configured here.
+

--- a/files/default/dummy.conf
+++ b/files/default/dummy.conf
@@ -1,0 +1,1 @@
+#an empty file because monit would not start if the conf.d dir is empty

--- a/libraries/monitrc.rb
+++ b/libraries/monitrc.rb
@@ -4,14 +4,22 @@ class Chef
     # variables   Hash of variables to pass to the template
     # reload      Reload monit so it notices the new service.  :delayed (default) or :immediately.
     def monitrc(name, variables={}, reload = :delayed)
-      log "Making monitrc for: #{name}"
-      template "/etc/monit/conf.d/#{name}.conf" do
+      Chef::Log.info "Making monitrc for: #{name}"
+
+      action = :restart
+      if platform?(%W(fedora centos redhat))
+        action = :reload
+      end
+
+      template "#{node[:monit][:include_dir]}/#{name}.conf" do
         owner "root"
         group "root"
         mode 0644
+        #this should be "monit/#{name}.conf.erb" or "#{name}.monit.conf.erb" to not conflict with other conf files
+        #but this is a non backward compat change. I'll leave it to the owner of the cookbook
         source "#{name}.conf.erb"
         variables variables
-        notifies :restart, resources(:service => "monit"), reload
+        notifies action, resources(:service => "monit"), reload
         action :create
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,9 @@ description      "Configures monit.  Originally based off the 37 Signals Cookboo
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.7"
 
+%w{debian ubuntu redhat centos fedora}.each do |os|
+  supports os
+end
 
 attribute 'monit/notify_email', 
   :description => 'The email address to send alerts to.',
@@ -20,4 +23,3 @@ attribute 'monit/poll_start_delay',
   :description => 'When monit first starts, how long to delay before it starts performing checks',
   :type => "string",
   :required => "recommended"
-

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,23 @@ package "monit" do
   action :install
 end
 
-if platform?("ubuntu")
+#### prepare directories and additional things ###
+include_dir = node[:monit][:include_dir]
+if platform?(%W(fedora centos redhat))
+  directory include_dir do
+    owner 'root'
+    group 'root'
+    action :create
+    recursive true
+  end
+else
+  #assume debian|ubuntu
+  directory include_dir do
+    owner 'root'
+    group 'root'
+    action :create
+    recursive true
+  end
   cookbook_file "/etc/default/monit" do
     source "monit.default"
     owner "root"
@@ -10,25 +26,39 @@ if platform?("ubuntu")
     mode 0644
   end
 end
+cookbook_file "#{include_dir}/dummy.conf" do
+  #this is a dummy file in conf.d, monit will not start with this directory empty
+  source "dummy.conf"
+end
+
+#### main conf ####
+if platform?(%W(fedora centos redhat))
+  template "monit_conf" do
+    path "/etc/monit.conf"
+    source 'monitrc.erb'
+    owner "root"
+    group "root"
+    variables :include_path => "#{include_dir}/*.conf"
+  end
+else
+  #assume debian|ubuntu
+  template "monit_conf" do
+    path "/etc/monit/monitrc"
+    source 'monitrc.erb'
+    owner "root"
+    group "root"
+    variables :include_path => "#{include_dir}/*.conf"
+  end
+end
+
+#### service ####
+supports = [:start, :restart, :stop]
+if platform?(%W(fedora centos redhat))
+  supports << :reload
+end
 
 service "monit" do
-  action :start
-  enabled true
-  supports [:start, :restart, :stop]
-end
-
-template "/etc/monit/monitrc" do
-  owner "root"
-  group "root"
-  mode 0700
-  source 'monitrc.erb'
-  notifies :restart, resources(:service => "monit"), :immediate
-end
-
-directory "/etc/monit/conf.d/" do
-  owner  'root'
-  group 'root'
-  mode 0755
-  action :create
-  recursive true
+  action [:enable, :start]
+  supports supports
+  subscribes :restart, resources(:template => "monit_conf"), :immediate
 end

--- a/templates/centos/monitrc.erb
+++ b/templates/centos/monitrc.erb
@@ -17,7 +17,6 @@
 ## Start Monit in the background (run as a daemon):
 #
 set daemon  <%= @node[:monit][:poll_period] %>                 # check services at 2-minute intervals
-     with start delay <%= @node[:monit][:poll_start_delay] %>  # optional: delay the first check by 4-minutes (by
 #                                                              # default Monit check immediately after Monit start)
 #
 #
@@ -49,7 +48,6 @@ set logfile syslog facility log_daemon
 # set mailserver mail.bar.baz,               # primary mailserver
 #                backup.bar.baz port 10025,  # backup mailserver on port 10025
 #                localhost                   # fallback relay
-set mailserver localhost
 #
 #
 ## By default Monit will drop alert events if no mail servers are available.
@@ -59,8 +57,8 @@ set mailserver localhost
 ## size using the SLOTS option (if omitted, the queue is limited by space
 ## available in the back end filesystem).
 #
-set eventqueue
-    basedir /var/monit  # set the base directory where events will be stored
+# set eventqueue
+#     basedir /var/monit  # set the base directory where events will be stored
 #     slots 100           # optionally limit the queue size
 #
 #
@@ -105,9 +103,6 @@ set mail-format {
 # set alert sysadm@foo.bar                       # receive all alerts
 # set alert manager@foo.bar only on { timeout }  # receive just service-
 #                                                # timeout alert
-
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
-
 #
 #
 ## Monit has an embedded web server which can be used to view status of
@@ -245,5 +240,3 @@ set httpd port 2812 and
 #
 
 include <%= @include_path %>
-
-

--- a/templates/fedora/monitrc.erb
+++ b/templates/fedora/monitrc.erb
@@ -17,7 +17,6 @@
 ## Start Monit in the background (run as a daemon):
 #
 set daemon  <%= @node[:monit][:poll_period] %>                 # check services at 2-minute intervals
-     with start delay <%= @node[:monit][:poll_start_delay] %>  # optional: delay the first check by 4-minutes (by
 #                                                              # default Monit check immediately after Monit start)
 #
 #
@@ -49,7 +48,6 @@ set logfile syslog facility log_daemon
 # set mailserver mail.bar.baz,               # primary mailserver
 #                backup.bar.baz port 10025,  # backup mailserver on port 10025
 #                localhost                   # fallback relay
-set mailserver localhost
 #
 #
 ## By default Monit will drop alert events if no mail servers are available.
@@ -59,8 +57,8 @@ set mailserver localhost
 ## size using the SLOTS option (if omitted, the queue is limited by space
 ## available in the back end filesystem).
 #
-set eventqueue
-    basedir /var/monit  # set the base directory where events will be stored
+# set eventqueue
+#     basedir /var/monit  # set the base directory where events will be stored
 #     slots 100           # optionally limit the queue size
 #
 #
@@ -105,9 +103,6 @@ set mail-format {
 # set alert sysadm@foo.bar                       # receive all alerts
 # set alert manager@foo.bar only on { timeout }  # receive just service-
 #                                                # timeout alert
-
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
-
 #
 #
 ## Monit has an embedded web server which can be used to view status of
@@ -245,5 +240,3 @@ set httpd port 2812 and
 #
 
 include <%= @include_path %>
-
-

--- a/templates/redhat/monitrc.erb
+++ b/templates/redhat/monitrc.erb
@@ -17,7 +17,6 @@
 ## Start Monit in the background (run as a daemon):
 #
 set daemon  <%= @node[:monit][:poll_period] %>                 # check services at 2-minute intervals
-     with start delay <%= @node[:monit][:poll_start_delay] %>  # optional: delay the first check by 4-minutes (by
 #                                                              # default Monit check immediately after Monit start)
 #
 #
@@ -49,7 +48,6 @@ set logfile syslog facility log_daemon
 # set mailserver mail.bar.baz,               # primary mailserver
 #                backup.bar.baz port 10025,  # backup mailserver on port 10025
 #                localhost                   # fallback relay
-set mailserver localhost
 #
 #
 ## By default Monit will drop alert events if no mail servers are available.
@@ -59,8 +57,8 @@ set mailserver localhost
 ## size using the SLOTS option (if omitted, the queue is limited by space
 ## available in the back end filesystem).
 #
-set eventqueue
-    basedir /var/monit  # set the base directory where events will be stored
+# set eventqueue
+#     basedir /var/monit  # set the base directory where events will be stored
 #     slots 100           # optionally limit the queue size
 #
 #
@@ -105,9 +103,6 @@ set mail-format {
 # set alert sysadm@foo.bar                       # receive all alerts
 # set alert manager@foo.bar only on { timeout }  # receive just service-
 #                                                # timeout alert
-
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
-
 #
 #
 ## Monit has an embedded web server which can be used to view status of
@@ -245,5 +240,3 @@ set httpd port 2812 and
 #
 
 include <%= @include_path %>
-
-


### PR DESCRIPTION
Hi,

I have updated the cookbook to be multi platform, I also updated the monitrc files to look like the packaged one.

I've also made a comment in the definition to namespace the source file path. The version I use here is of the form "monit/#{name}.conf.erb".

Thanks for considering

--Gilles
