### PR TITLE
Defintion fixes

### DIFF
--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,18 +1,18 @@
 # reload      Reload monit so it notices the new service.  :delayed (default) or :immediately.
 define :monitrc, :action => :enable, :reload => :delayed do
   if params[:enable]
-    template "/etc/monit/conf.d/#{name}.conf" do
+    template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"
       group "root"
       mode 0644
-      source "#{name}.conf.erb"
+      source "#{params[:name]}.conf.erb"
       cookbook "monit"
       variables params
       notifies :restart, resources(:service => "monit"), params[:reload]
       action :create
     end
   else
-    template "/etc/monit/conf.d/#{name}.conf" do
+    template "/etc/monit/conf.d/#{params[:name]}.conf" do
       action :delete
       notifies :restart, resources(:service => "monit"), params[:reload]
     end

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,5 +1,5 @@
 # reload      Reload monit so it notices the new service.  :delayed (default) or :immediately.
-define :monitrc, :action => :enable, :reload => :delayed do
+define :monitrc, :enable => true, :reload => :delayed do
   if params[:enable]
     template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,12 +1,12 @@
 # reload      Reload monit so it notices the new service.  :delayed (default) or :immediately.
-define :monitrc, :enable => true, :reload => :delayed do
+define :monitrc, :enable => true, :reload => :delayed, :source => "#{params[:name]}.conf.erb", :cookbook => "monit" do
   if params[:enable]
     template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"
       group "root"
       mode 0644
-      source "#{params[:name]}.conf.erb"
-      cookbook "monit"
+      source params[:source]
+      cookbook params[:cookbook]
       variables params
       notifies :restart, resources(:service => "monit"), params[:reload]
       action :create

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,11 +1,11 @@
 # reload      Reload monit so it notices the new service.  :delayed (default) or :immediately.
-define :monitrc, :enable => true, :reload => :delayed, :source => "#{params[:name]}.conf.erb", :cookbook => "monit" do
+define :monitrc, :enable => true, :reload => :delayed, :cookbook => "monit" do
   if params[:enable]
     template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"
       group "root"
       mode 0644
-      source params[:source]
+      source params[:source] || "#{params[:name].conf}"
       cookbook params[:cookbook]
       variables params
       notifies :restart, resources(:service => "monit"), params[:reload]


### PR DESCRIPTION
Had to rename some variables in order to make the `monitrc` definition work. Here are my changes.
