### PR TITLE
Miscellaneous bugfixes and improvements

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,8 @@ Yours sincerely,
 monit
 EOS
 
+default[:monit][:mailserver][:host] = "localhost"
+default[:monit][:mailserver][:port] = nil
+default[:monit][:mailserver][:username] = nil
+default[:monit][:mailserver][:password] = nil
+default[:monit][:mailserver][:password_suffix] = nil

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,18 +1,19 @@
-# reload      Reload monit so it notices the new service.  :delayed (default) or :immediately.
+# reload: Reload monit so it notices the new service.  :delayed (default) or :immediately.
+# action: :enable To create the monitoring config (default), or :disable to remove it.
 define :monitrc, :action => :enable, :reload => :delayed do
-  if params[:enable]
-    template "/etc/monit/conf.d/#{name}.conf" do
+  if params[:action] == :enable
+    template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"
       group "root"
       mode 0644
-      source "#{name}.conf.erb"
+      source "#{params[:name]}.conf.erb"
       cookbook "monit"
       variables params
       notifies :restart, resources(:service => "monit"), params[:reload]
       action :create
     end
   else
-    template "/etc/monit/conf.d/#{name}.conf" do
+    template "/etc/monit/conf.d/#{params[:name]}.conf" do
       action :delete
       notifies :restart, resources(:service => "monit"), params[:reload]
     end

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,6 +1,6 @@
 # reload: Reload monit so it notices the new service.  :delayed (default) or :immediately.
 # action: :enable To create the monitoring config (default), or :disable to remove it.
-define :monitrc, :action => :enable, :reload => :delayed do
+define :monitrc, :action => :enable, :reload => :delayed, :variables => {} do
   if params[:action] == :enable
     template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"
@@ -8,7 +8,7 @@ define :monitrc, :action => :enable, :reload => :delayed do
       mode 0644
       source "#{params[:name]}.conf.erb"
       cookbook "monit"
-      variables params
+      variables params[:variables]
       notifies :restart, resources(:service => "monit"), params[:reload]
       action :create
     end

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -1,13 +1,17 @@
 # reload: Reload monit so it notices the new service.  :delayed (default) or :immediately.
 # action: :enable To create the monitoring config (default), or :disable to remove it.
-define :monitrc, :action => :enable, :reload => :delayed, :variables => {} do
+# variables: Hash of instance variables to pass to the ERB template
+# template_cookbook: the cookbook in which the configuration resides
+# template_source: filename of the ERB configuration template, defaults to <LWRP Name>.conf.erb
+define :monitrc, :action => :enable, :reload => :delayed, :variables => {}, :template_cookbook => "monit", :template_source => nil do
+  params[:template_source] ||= "#{params[:name]}.conf.erb"
   if params[:action] == :enable
     template "/etc/monit/conf.d/#{params[:name]}.conf" do
       owner "root"
       group "root"
       mode 0644
-      source "#{params[:name]}.conf.erb"
-      cookbook "monit"
+      source params[:template_source]
+      cookbook params[:template_cookbook]
       variables params[:variables]
       notifies :restart, resources(:service => "monit"), params[:reload]
       action :create

--- a/files/default/init-monit-ubuntu12.sh
+++ b/files/default/init-monit-ubuntu12.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          monit
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Should-Start:      $all
+# Should-Stop:       $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: service and resource monitoring daemon
+# Description:       monit is a utility for managing and monitoring
+#                    processes, programs, files, directories and filesystems
+#                    on a Unix system. Monit conducts automatic maintenance
+#                    and repair and can execute meaningful causal actions
+#                    in error situations.
+### END INIT INFO
+
+set -e
+
+. /lib/lsb/init-functions
+
+DAEMON=/usr/bin/monit
+CONFIG="/etc/monit/monitrc"
+DELAY="/etc/monit/monit_delay"
+NAME=monit
+DESC="daemon monitor"
+MONIT_OPTS=
+PID="/var/run/$NAME.pid"
+
+# Check if DAEMON binary exist
+[ -f $DAEMON ] || exit 0
+
+[ -f "/etc/default/$NAME" ] && . /etc/default/$NAME
+
+# For backward compatibility, handle startup variable:
+if [ -n "$startup" ]
+then
+  if [ "$1" = "start" ]
+  then
+    printf "\tPlease, use START variable in /etc/default/monit\n"
+    printf "\tto enable/disable $NAME startup.\n"
+  fi
+
+  if [ -z "$START" ] && [ "$startup" -eq 1 ]
+  then
+    START="yes"
+  fi
+fi
+
+# For backward compatibility, handle CHECK_INTERVALS variable:
+if [ -n "$CHECK_INTERVALS" ]
+then
+  if [ "$1" = "start" ]
+  then
+    printf "\tPlease, use MONIT_OPTS variable in /etc/default/monit\n"
+    printf "\tto specify command line options for $NAME.\n"
+  fi
+
+  MONIT_OPTS="$MONIT_OPTS -d $CHECK_INTERVALS"
+fi
+
+MONIT_OPTS="-c $CONFIG $MONIT_OPTS"
+
+monit_not_configured () {
+  if [ "$1" != "stop" ]
+  then
+    printf "\tplease configure $NAME and then edit /etc/default/$NAME\n"
+    printf "\tand set the \"START\" variable to \"yes\" in order to allow\n"
+    printf "\t$NAME to start\n"
+  fi
+  exit 0
+}
+
+monit_check_config () {
+  # Check for emtpy config.
+  if [ "`grep -s -v \"^#\" $CONFIG`" = "" ]
+  then
+    echo "empty config, please edit $CONFIG."
+    exit 0
+  fi
+}
+
+monit_check_perms () {
+  # Check the permission on configfile.
+  # The permission must not have more than -rwx------ (0700) permissions.
+
+  # Skip checking, fix perms instead.
+  /bin/chmod go-rwx $CONFIG
+}
+
+monit_delayed_monitoring () {
+  if [ -f $DELAY ]
+  then
+    printf "Warning: Please, set start delay for $NAME in config file\n"
+    printf "         and delete $DELAY file.\n"
+
+    if [ ! -x $DELAY ]
+    then
+      printf "Warning: A delayed start file exists ($DELAY)\n"
+      printf "         but it is not executable.\n"
+    else
+      $DELAY &
+    fi
+  fi
+}
+
+monit_checks () {
+  # Check if START variable is set to "yes", if not we exit.
+  if [ "$START" != "yes" ]
+  then
+    monit_not_configured $1
+  fi
+  # Check for emtpy configfile
+  monit_check_config
+  # Check permissions of configfile
+  monit_check_perms
+}
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC" "$NAME"
+    monit_checks $1
+    if start-stop-daemon --start --quiet --oknodo \
+                         --pidfile $PID --exec $DAEMON \
+                         -- $MONIT_OPTS
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+    monit_delayed_monitoring
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    if start-stop-daemon --retry TERM/5/KILL/5 --oknodo --stop --quiet \
+                         --pidfile $PID --exec $DAEMON
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
+    ;;
+  reload)
+    log_daemon_msg "Reloading $DESC configuration" "$NAME"
+    if start-stop-daemon --stop --signal HUP --quiet \
+                                --oknodo --pidfile $PID \
+                                --exec $DAEMON -- $MONIT_OPTS
+    then
+      log_end_msg 0
+    else
+      log_end_msg 1
+	fi
+    ;;
+  restart|force-reload)
+    $0 stop
+    $0 start
+    ;;
+  syntax)
+    $DAEMON $MONIT_OPTS -t
+    ;;
+  status)
+    status_of_proc -p $PID $DAEMON $NAME
+    ;;
+  *)
+    log_action_msg "Usage: /etc/init.d/$NAME {start|stop|reload|restart|force-reload|syntax|status}"
+    ;;
+esac
+
+exit 0

--- a/recipes/ubuntu12fix.rb
+++ b/recipes/ubuntu12fix.rb
@@ -1,0 +1,7 @@
+# Working init script, fix for: https://bugs.launchpad.net/ubuntu/+source/monit/+bug/993381
+cookbook_file "/etc/init.d/monit" do
+  source 'init-monit-ubuntu12.sh'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -1,5 +1,7 @@
 set daemon <%= @node[:monit][:poll_period] %>
+<% if @node[:monit][:poll_start_delay] %>
   with start delay <%= @node[:monit][:poll_start_delay] %>
+<% end %>
 
 set logfile syslog facility log_daemon
 

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -3,7 +3,13 @@ set daemon <%= @node[:monit][:poll_period] %>
 
 set logfile syslog facility log_daemon
 
-set mailserver localhost
+set mailserver <%= @node[:monit][:mailserver][:host] %><%= " port #{@node[:monit][:mailserver][:port]}" if @node[:monit][:mailserver][:host] %>
+<% if @node[:monit][:mailserver][:username] %>
+  username "<%= @node[:monit][:mailserver][:username] %>"
+<% end %>
+<% if @node[:monit][:mailserver][:password] %>
+  password "<%= @node[:monit][:mailserver][:password] %>"<%= " #{@node[:monit][:mailserver][:password_suffix]}" if @node[:monit][:mailserver][:password_suffix] %>
+<% end %>
 
 set eventqueue
     basedir /var/monit  # set the base directory where events will be stored


### PR DESCRIPTION
In addition to fixing the issue I filed, I add a few improvements:
- Custom configurable mail servers
- Make the monitrc definition more generic by allowing it to be accessed from third party cookbooks. This way, for instance, the riak cookbook can control the riak monit configuration, needing only to include the monit recipe.
- Provide a working init.d script for ubuntu 12. The one that ships is invalid bash: https://bugs.launchpad.net/ubuntu/+source/monit/+bug/993381 I put this in its own recipe so that it can be explicitly included or not used.

Each change is in its own commit, so feel free to cherry-pick if there is something you see that you don't like.
