### PR TITLE
Add chef-client monit conf.

### DIFF
--- a/recipes/chef-client.rb
+++ b/recipes/chef-client.rb
@@ -1,0 +1,3 @@
+include_recipe "monit"
+
+monitrc "chef-client"

--- a/templates/default/chef-client.conf.erb
+++ b/templates/default/chef-client.conf.erb
@@ -1,0 +1,4 @@
+check process chef-client
+  with pidfile "/var/run/chef/client.pid"
+  start program = "/etc/init.d/chef-client start"
+  stop program = "/etc/init.d/chef-client stop"


### PR DESCRIPTION
I think it's safe to say most people could use this, right? The pid path and init style may not work for all platforms of course, but these values work for most ubuntu setups I believe.
