### PR TITLE
Add monit chef handler

### DIFF
--- a/files/default/monit_handler.rb
+++ b/files/default/monit_handler.rb
@@ -1,0 +1,24 @@
+require "rubygems"
+require "chef"
+require "chef/handler"
+
+class MonitHandler < Chef::Handler
+
+  def initialize(opts = {})
+    @poll_period = opts[:poll_period] || 1
+  end
+
+  def report
+    if system("ps -e | grep `cat /var/run/monit.pid`")
+      did_monitor = system("monit monitor all")
+      if did_monitor
+        Chef::Log.info "Monit monitor all succeeded"
+      else
+        Chef::Log.info "Monit monitor all failed, waiting #{@poll_period} seconds before trying again"
+        did_monitor = system("sleep #{@poll_period} && monit monitor all")
+      end
+      Chef::Log.info("Monit monitor all failed") unless did_monitor
+    end
+  end
+
+end

--- a/files/default/monit_handler.rb
+++ b/files/default/monit_handler.rb
@@ -8,16 +8,21 @@ class MonitHandler < Chef::Handler
     @poll_period = opts[:poll_period] || 1
   end
 
+  def success
+    Chef::Log.info "Monit monitor all succeeded"
+  end
+
+  def failure
+    Chef::Log.warn "Monit monitor all failed"
+  end
+
   def report
     if system("ps -e | grep `cat /var/run/monit.pid`")
-      did_monitor = system("monit monitor all")
-      if did_monitor
-        Chef::Log.info "Monit monitor all succeeded"
-      else
-        Chef::Log.info "Monit monitor all failed, waiting #{@poll_period} seconds before trying again"
-        did_monitor = system("sleep #{@poll_period} && monit monitor all")
-      end
-      Chef::Log.info("Monit monitor all failed") unless did_monitor
+      return success if system("monit monitor all")
+      failure
+      Chef::Log.warn "Waiting #{@poll_period} seconds before trying again..."
+      return success if system("sleep #{@poll_period} && monit monitor all")
+      failure
     end
   end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,7 @@ description      "Configures monit.  Originally based off the 37 Signals Cookboo
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.7"
 
+depends "chef_handler"
 
 attribute 'monit/notify_email', 
   :description => 'The email address to send alerts to.',

--- a/recipes/handler.rb
+++ b/recipes/handler.rb
@@ -1,0 +1,37 @@
+# Unmonitor services that might be manipulated by the chef run
+e = execute "monit unmonitor all" do
+  action :nothing
+  only_if "ps -e | grep `cat /var/run/monit.pid`"
+  ignore_failure true
+end
+e.run_action(:run)
+
+# Monitor chef-client in case it bails mid-run
+e = execute "monit monitor chef-client" do
+  action :nothing
+  only_if { File.exists?("/etc/monit/conf.d/chef-client.conf") }
+  ignore_failure true
+end
+e.run_action(:run)
+
+# Install monit chef handler
+include_recipe "chef_handler"
+
+directory node["chef_handler"]["handler_path"] do
+  owner "root"
+  group "root"
+  mode  "0755"
+end
+
+handler_path = ::File.join(node["chef_handler"]["handler_path"], "monit_handler.rb")
+cookbook_file handler_path do
+  owner "root"
+  group "root"
+  mode  "0644"
+end
+
+chef_handler "MonitHandler" do
+  source handler_path
+  action :enable
+  arguments :poll_period => node["monit"]["poll_period"]
+end

--- a/recipes/handler.rb
+++ b/recipes/handler.rb
@@ -1,7 +1,7 @@
 # Unmonitor services that might be manipulated by the chef run
 e = execute "monit unmonitor all" do
   action :nothing
-  only_if "ps -e | grep `cat /var/run/monit.pid`"
+  only_if "ps -e | grep -q `cat /var/run/monit.pid`"
   ignore_failure true
 end
 e.run_action(:run)
@@ -9,7 +9,7 @@ e.run_action(:run)
 # Monitor chef-client in case it bails mid-run
 e = execute "monit monitor chef-client" do
   action :nothing
-  only_if { File.exists?("/etc/monit/conf.d/chef-client.conf") }
+  only_if "ps -e | grep -q `cat /var/run/monit.pid` && monit summary | grep -q \"Process 'chef-client'\""
   ignore_failure true
 end
 e.run_action(:run)


### PR DESCRIPTION
This PR adds a chef handler for monit that automatically unmonitors all services during a chef-client run, remonitoring them afterward. It was created to prevent monit from restarting, alerting, and just generally freaking out when chef manipulates service resources.

The handler has no effect if http isn't enabled in monitrc or localhost isn't allowed, since that's how the monit command line client communicates with the service. Install the handler by including the `monit::handler` recipe. Similarly to #14, there are a few assumptions regarding paths that may be platform-specific to Ubuntu.

Bonus: If a monit config for chef-client is found, the chef-client service is never unmonitored. That way, monit will still restart chef-client if it happens to bail mid-run.
