### PR TITLE
Use attributes to configure http settings in monitrc.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,3 +16,9 @@ default[:monit][:mailserver][:port] = nil
 default[:monit][:mailserver][:username] = nil
 default[:monit][:mailserver][:password] = nil
 default[:monit][:mailserver][:password_suffix] = nil
+
+default[:monit][:port] = 3737
+default[:monit][:address] = "localhost"
+default[:monit][:ssl] = false
+default[:monit][:cert] = "/etc/monit/monit.pem"
+default[:monit][:allow] = ["localhost"]

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -25,9 +25,15 @@ set mail-format {
 
 set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
 
-set httpd port 3737 and
-    use address localhost
-    allow localhost
+set httpd port <%= node[:monit][:port] %>
+  <%= "use address #{node[:monit][:address]}" if node[:monit][:address] %>
+<% node[:monit][:allow].each do |a| %>
+  allow <%= "#{a}" %>
+<% end %>
+<% if node[:monit][:ssl] %>
+  ssl enable
+  pemfile <%= node[:monit][:cert] %>
+<% end %>
 
 include /etc/monit/conf.d/*.conf
 


### PR DESCRIPTION
Pull http configuration out into node attributes. Also add SSL support (off by default). The values in `attributes/default.rb` should reflect the previously hardcoded values.
