### PR TITLE
Bump directory creation up so /etc/monit exists

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,18 +15,18 @@ service "monit" do
   supports [:start, :restart, :stop]
 end
 
-template "/etc/monit/monitrc" do
-  owner "root"
-  group "root"
-  mode 0700
-  source 'monitrc.erb'
-  notifies :restart, resources(:service => "monit"), :delayed
-end
-
 directory "/etc/monit/conf.d/" do
   owner  'root'
   group 'root'
   mode 0755
   action :create
   recursive true
+end
+
+template "/etc/monit/monitrc" do
+  owner "root"
+  group "root"
+  mode 0700
+  source 'monitrc.erb'
+  notifies :restart, resources(:service => "monit"), :delayed
 end


### PR DESCRIPTION
The creation of /etc/monit/monitrc fails because /etc/monit doesn't exist.  Moving the creation of /etc/monit/conf.d up above fixes this.
