### PR TITLE
install the postfix package in recipe ::postfix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+gem 'chefspec'
+gem 'fauxhai'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,95 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    builder (3.1.4)
+    bunny (0.7.9)
+    chef (10.18.2)
+      bunny (>= 0.6.0, < 0.8.0)
+      erubis
+      highline (>= 1.6.9)
+      json (>= 1.4.4, <= 1.6.1)
+      mixlib-authentication (>= 1.3.0)
+      mixlib-cli (>= 1.1.0)
+      mixlib-config (>= 1.1.2)
+      mixlib-log (>= 1.3.0)
+      mixlib-shellout
+      moneta (< 0.7.0)
+      net-ssh (~> 2.2.2)
+      net-ssh-multi (~> 1.1.0)
+      ohai (>= 0.6.0)
+      rest-client (>= 1.0.4, < 1.7.0)
+      treetop (~> 1.4.9)
+      uuidtools
+      yajl-ruby (~> 1.1)
+    chefspec (0.9.0)
+      chef (>= 0.9.12)
+      erubis
+      minitest-chef-handler (~> 0.6.0)
+      rspec (~> 2.11.0)
+    ci_reporter (1.8.3)
+      builder (>= 2.1.2)
+    diff-lcs (1.1.3)
+    erubis (2.7.0)
+    fauxhai (0.1.1)
+      chef
+      httparty
+      net-ssh
+    highline (1.6.15)
+    httparty (0.10.0)
+      multi_json (~> 1.0)
+      multi_xml
+    ipaddress (0.8.0)
+    json (1.6.1)
+    mime-types (1.19)
+    minitest (4.5.0)
+    minitest-chef-handler (0.6.5)
+      chef
+      ci_reporter
+      minitest
+    mixlib-authentication (1.3.0)
+      mixlib-log
+    mixlib-cli (1.3.0)
+    mixlib-config (1.1.2)
+    mixlib-log (1.4.1)
+    mixlib-shellout (1.1.0)
+    moneta (0.6.0)
+    multi_json (1.5.0)
+    multi_xml (0.5.2)
+    net-ssh (2.2.2)
+    net-ssh-gateway (1.1.0)
+      net-ssh (>= 1.99.1)
+    net-ssh-multi (1.1)
+      net-ssh (>= 2.1.4)
+      net-ssh-gateway (>= 0.99.0)
+    ohai (6.16.0)
+      ipaddress
+      mixlib-cli
+      mixlib-config
+      mixlib-log
+      mixlib-shellout
+      systemu
+      yajl-ruby
+    polyglot (0.3.3)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.1)
+    rspec-expectations (2.11.3)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.11.3)
+    systemu (2.5.2)
+    treetop (1.4.12)
+      polyglot
+      polyglot (>= 0.3.1)
+    uuidtools (2.1.3)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  chefspec
+  fauxhai

--- a/recipes/postfix.rb
+++ b/recipes/postfix.rb
@@ -1,3 +1,4 @@
 include_recipe "monit"
 
+package "postfix"
 monitrc "postfix"

--- a/spec/postfix_spec.rb
+++ b/spec/postfix_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'monit::postfix' do
+  let(:chef_run) { runner.converge 'monit::postfix' }
+
+  it "includes the default recipe" do
+    chef_run.should include_recipe "monit"
+  end
+
+  it "installs postfix" do
+    chef_run.should install_package "postfix"
+  end
+
+  it "creates the postfix.conf" do
+    chef_run.should create_file_with_content "/etc/monit/conf.d/postfix.conf", "CHECK PROCESS postfix WITH PIDFILE /var/spool/postfix/pid/master.pid"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+require 'chefspec'
+require 'fauxhai'
+
+Dir["./spec/support/**/*.rb"].sort.each {|f| require f}
+
+RSpec.configure do |config|
+  config.before(:each) do
+    # Change this to whatever OS you want to stub out, or move it into a before block if different spec files need different OSes.
+    Fauxhai.mock(platform: 'ubuntu', version: '10.04')
+  end
+end
+
+# Chef normally defaults to the '_default' environment. For tests, run by default in the 'test' environment.
+def runner(environment = "test")
+  # A workaround so that ChefSpec can work with Chef environments (from https://github.com/acrmp/chefspec/issues/54)
+
+  @runner ||= ChefSpec::ChefRunner.new do |node|
+    env = Chef::Environment.new
+    env.name environment
+
+    node.stub(:chef_environment).and_return env.name
+    Chef::Environment.stub(:load).and_return env
+  end
+end


### PR DESCRIPTION
I ran the monit::postfix recipe and noticed the monitoring wasn't working because postfix wasn't installed, so I've added it to the recipe.

I also added tests with [ChefSpec](https://github.com/acrmp/chefspec); it's a cool RSpec-based unit-testing framework for cookbooks.
