### PR TITLE
only set email alerts if node[:monit][:notify_email] is not nil (defaults to nil)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default["monit"]["notify_email"]          = "notify@example.com"
+default["monit"]["notify_email"]          = nil
 default["monit"]["alert_blacklist"]       = %w( action instance pid ppid )
 
 default["monit"]["logfile"]               = 'syslog facility log_daemon'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 
 describe 'monit::default' do
   context "with default attributes" do
-    let(:chef_run) do
-      runner = ChefSpec::Runner.new.converge(described_recipe)
-    end
+    let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
 
     it 'creates /etc/monit/conf.d/' do
       expect(chef_run).to create_directory('/etc/monit/conf.d/').with(user: 'root', group: 'root', mode: 0755)
@@ -26,6 +24,10 @@ describe 'monit::default' do
 
     it 'start the service' do
       expect(chef_run).to start_service('monit') 
+    end
+
+    it 'does not email notifications' do
+      expect(chef_run).not_to render_file('/etc/monit/monitrc').with_content(/set alert /)
     end
   end
 

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -31,7 +31,9 @@ set mail-format {
   message: <%= @node["monit"]["mail_format"]["message"] %>
 }
 
-set alert <%= @node["monit"]["notify_email"] %><%= " NOT ON { #{@node["monit"]["alert_blacklist"].join(", ")} }" unless @node["monit"]["alert_blacklist"].empty? %>
+<% unless @node[:monit][:notify_email].nil? %>
+  set alert <%= @node["monit"]["notify_email"] %><%= " NOT ON { #{@node["monit"]["alert_blacklist"].join(", ")} }" unless @node["monit"]["alert_blacklist"].empty? %>
+<% end %>
 
 set httpd port <%= @node["monit"]["port"] %>
   <%= "use address #{@node["monit"]["address"]}" if @node["monit"]["address"] %>


### PR DESCRIPTION
Sometimes (for example in test environments), I don't want Monit to send email alerts.

I also added tests with [ChefSpec](https://github.com/acrmp/chefspec); it's a cool RSpec-based unit-testing framework for cookbooks.
