### PR TITLE
Ignored events configurable via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default[:monit][:notify_email]          = "notify@example.com"
+default[:monit][:ignored_events]        = ["action", "instance", "pid", "ppid"]
 
 default[:monit][:poll_period]           = 60
 default[:monit][:poll_start_delay]      = 120

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -17,13 +17,13 @@ set eventqueue
     basedir /var/monit  # set the base directory where events will be stored
 #    slots 1000          # optionaly limit the queue size
 
-set mail-format { 
+set mail-format {
   from: <%= @node[:monit][:mail_format][:from] %>
   subject: <%= @node[:monit][:mail_format][:subject] %>
   message: <%= @node[:monit][:mail_format][:message] %>
 }
 
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
+set alert <%= @node[:monit][:notify_email] %> NOT ON { <%= @node[:monit][:ignored_events].join(", ") %> }
 
 set httpd port <%= node[:monit][:port] %>
   <%= "use address #{node[:monit][:address]}" if node[:monit][:address] %>


### PR DESCRIPTION
Older versions of monit (< 5.0) do not recognize some events and will issue a
syntax error if they are included in the config. This change allows the ignored
events to be defined in an attribute so they can be changed per node.
