### PR TITLE
kindly accept simple pull request to add name to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "monit"
 maintainer       "Alex Soto"
 maintainer_email "apsoto@gmail.com"
 license          "MIT"
@@ -6,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.7"
 
 
-attribute 'monit/notify_email', 
+attribute 'monit/notify_email',
   :description => 'The email address to send alerts to.',
   :type => "string",
   :required => "recommended"


### PR DESCRIPTION
berkshelf cannot upload cookbooks to the opensource chef-server unless
metadata.name exists.
Here's the bug: https://github.com/RiotGames/berkshelf/issues/442
However I believe this bug will not be fixed. No one is assigned AND no
milestone.

I've been told by a chef developer (jtimberman @ irc freenode #chef) :
"12:10 @jtimberman david415: we have a CHEF ticket to make it
required, but that's a breaking change, so it would be Chef 12 since we
didn't get it in time for Chef 11."
