### PR TITLE
enable monit on debian based systems via defaults file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "monit"
 maintainer       "Alex Soto"
 maintainer_email "apsoto@gmail.com"
 license          "MIT"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,3 +30,11 @@ template "/etc/monit/monitrc" do
   source 'monitrc.erb'
   notifies :restart, resources(:service => "monit"), :delayed
 end
+
+template "/etc/default/monit" do
+  owner "root"
+  group "root"
+  mode 0644
+  source 'monit.erb'
+  only_if { node['platform_family'] == 'debian' }
+end

--- a/templates/debian-6.0.7/monit.erb
+++ b/templates/debian-6.0.7/monit.erb
@@ -4,7 +4,7 @@
 # Stefan Alfredsson <alfs@debian.org>
 
 # You must set this variable to for monit to start
-START=yes
+startup=1
 
 # You can change the location of the state file here
 # It can also be set in monitrc

--- a/templates/debian/monit.erb
+++ b/templates/debian/monit.erb
@@ -1,0 +1,15 @@
+# Defaults for monit initscript
+# sourced by /etc/init.d/monit
+# installed at /etc/default/monit by maintainer scripts
+# Stefan Alfredsson <alfs@debian.org>
+
+# You must set this variable to for monit to start
+startup=1
+
+# You can change the location of the state file here
+# It can also be set in monitrc
+# STATEFILE="/var/lib/monit/monit.state"
+
+# To change the intervals which monit should run,
+# edit the configuration file /etc/monit/monitrc
+# It can no longer be configured here.


### PR DESCRIPTION
During testing of monit I noticed it wouldn't start on Debian. Added the missing template for Debian based systems to always enable startup. Could be made configurable through node attributes but I didn't think that would be necessary just yet.
