### PR TITLE
make ssh port a variable / secure mailserver auth

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,3 +22,5 @@ default[:monit][:address] = "localhost"
 default[:monit][:ssl] = false
 default[:monit][:cert] = "/etc/monit/monit.pem"
 default[:monit][:allow] = ["localhost"]
+
+default[:monit][:ssh_port] = 22

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,7 @@ default[:monit][:mailserver][:port] = nil
 default[:monit][:mailserver][:username] = nil
 default[:monit][:mailserver][:password] = nil
 default[:monit][:mailserver][:password_suffix] = nil
+default[:monit][:mailserver][:secure_with] = nil
 
 default[:monit][:port] = 3737
 default[:monit][:address] = "localhost"

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -12,6 +12,9 @@ set mailserver <%= @node[:monit][:mailserver][:host] %><%= " port #{@node[:monit
 <% if @node[:monit][:mailserver][:password] %>
   password "<%= @node[:monit][:mailserver][:password] %>"<%= " #{@node[:monit][:mailserver][:password_suffix]}" if @node[:monit][:mailserver][:password_suffix] %>
 <% end %>
+<% if @node[:monit][:mailserver][:secure_with] %>
+  using "<%= @node[:monit][:mailserver][:secure_with] %>"
+<% end %>
 
 set eventqueue
     basedir /var/monit  # set the base directory where events will be stored

--- a/templates/default/ssh.conf.erb
+++ b/templates/default/ssh.conf.erb
@@ -3,5 +3,5 @@ CHECK PROCESS sshd WITH PIDFILE /var/run/sshd.pid
   START PROGRAM "/usr/sbin/service ssh start"
   STOP PROGRAM "/usr/sbin/service ssh stop"
   # under load a check may fail intermittently, so give it a few tries before restarting
-  IF FAILED PORT 22 PROTOCOL ssh 4 TIMES WITHIN 6 CYCLES THEN RESTART
+  IF FAILED PORT <%= @node[:monit][:ssh_port] %> PROTOCOL ssh 4 TIMES WITHIN 6 CYCLES THEN RESTART
 


### PR DESCRIPTION
It is very common to run ssh on a non-standard port -- make this a variable.

Also add option of configuring security/encryption to mailserver authentication.
