### PR TITLE
Fix for Ubuntu init script expectations

### DIFF
--- a/files/ubuntu/monit.default
+++ b/files/ubuntu/monit.default
@@ -4,6 +4,7 @@
 
 # You must set this variable to for monit to start
 startup=1
+START=yes
 
 # To change the intervals which monit should run,
 # edit the configuration file /etc/monit/monitrc


### PR DESCRIPTION
It appears Ubuntu changed monit's init script in the current release.
