### PR TITLE
An invalid monitrc breaks all future chef-client runs...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,12 +9,6 @@ if platform?("ubuntu")
   end
 end
 
-service "monit" do
-  action [:enable, :start]
-  enabled true
-  supports [:start, :restart, :stop]
-end
-
 directory "/etc/monit/conf.d/" do
   owner  'root'
   group 'root'
@@ -28,5 +22,11 @@ template "/etc/monit/monitrc" do
   group "root"
   mode 0700
   source 'monitrc.erb'
-  notifies :restart, resources(:service => "monit"), :delayed
+  notifies :restart, "service[monit]", :delayed
+end
+
+service "monit" do
+  action [:enable, :start]
+  enabled true
+  supports [:start, :restart, :stop]
 end


### PR DESCRIPTION
As it is now, if the monitrc file ever ends up in an invalid state, all future chef-client runs will fail, preventing you from fixing your mistake.
