### PR TITLE
Added an attribute `notify_emails` to setup multiple emails for alert notifications

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default[:monit][:notify_email]          = "notify@example.com"
+default[:monit][:notify_emails]         = {}
 
 default[:monit][:logfile]               = 'syslog facility log_daemon'
 
@@ -7,7 +8,7 @@ default[:monit][:poll_start_delay]      = 120
 
 default[:monit][:mail_format][:subject] = "$SERVICE $EVENT"
 default[:monit][:mail_format][:from]    = "monit@#{node['fqdn']}"
-default[:monit][:mail_format][:message]    = <<-EOS
+default[:monit][:mail_format][:message] = <<-EOS
 Monit $ACTION $SERVICE at $DATE on $HOST: $DESCRIPTION.
 Yours sincerely,
 monit

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,10 +7,14 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.7.1"
 
 
-attribute 'monit/notify_email', 
+attribute 'monit/notify_email',
   :description => 'The email address to send alerts to.',
   :type => "string",
   :required => "recommended"
+
+attribute 'monit/notify_emails',
+  :description => 'The email addresses to send alerts to.',
+  :type => "hash"
 
 attribute 'monit/poll_period',
   :description => 'How often to perform checks (in seconds)',

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -23,7 +23,15 @@ set mail-format {
   message: <%= @node[:monit][:mail_format][:message] %>
 }
 
+<% if @node[:monit][:notify_email] %>
 set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
+<% end %>
+
+<% if @node[:monit][:notify_emails] %>
+  <% @node[:monit][:notify_emails].each do |email, actions| %>
+set alert <%= email %> <%= "{#{actions}}" if actions && !actions.empty? %>
+  <% end %>
+<% end %>
 
 set httpd port <%= node[:monit][:port] %>
   <%= "use address #{node[:monit][:address]}" if node[:monit][:address] %>


### PR DESCRIPTION
I added ability to provide multiple emails:

``` ruby
default[:monit][:notify_emails]
```

So now we can handle multiple emails with different alert notifications. 

[Setting a  global alert statement](http://mmonit.com/monit/documentation/monit.html#setting_a_global_alert_statement)
