### PR TITLE
Don't impose a default for 'address' and 'allowed' attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 default[:monit][:notify_email]          = "notify@example.com"
+default[:monit][:alert_blacklist]       = []
 
 default[:monit][:logfile]               = 'syslog facility log_daemon'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,10 +22,10 @@ default[:monit][:mailserver][:encryption] = nil
 default[:monit][:mailserver][:timeout] = 60
 
 default[:monit][:port] = 3737
-default[:monit][:address] = "localhost"
+default[:monit][:address] = nil
 default[:monit][:ssl] = false
 default[:monit][:cert] = "/etc/monit/monit.pem"
-default[:monit][:allow] = ["localhost"]
+default[:monit][:allow] = []
 default[:monit][:username] = nil
 default[:monit][:password] = nil
 default[:monit][:ssh_port] = 22

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -29,7 +29,7 @@ set mail-format {
   message: <%= @node[:monit][:mail_format][:message] %>
 }
 
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
+set alert <%= @node[:monit][:notify_email] %><%= " NOT ON { #{@node[:monit][:alert_blacklist]} }" unless @node[:monit][:alert_blacklist].empty? %>
 
 set httpd port <%= @node[:monit][:port] %>
   <%= "use address #{@node[:monit][:address]}" if @node[:monit][:address] %>
@@ -43,4 +43,3 @@ set httpd port <%= @node[:monit][:port] %>
 <% end %>
 
 include /etc/monit/conf.d/*.conf
-


### PR DESCRIPTION
Remove the 'localhost' address and allowed attributes since they're optional in monitrc, but they don't get overwritten when setting them to null/empty in attributes json.
