### PR TITLE
Bugfix for Ubuntu & reload over restart for faster config updates

### DIFF
--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -13,13 +13,13 @@ define :monitrc, :action => :enable, :reload => :delayed, :variables => {}, :tem
       source params[:template_source]
       cookbook params[:template_cookbook]
       variables params[:variables]
-      notifies :restart, resources(:service => "monit"), params[:reload]
+      notifies :reload, resources(:service => "monit"), params[:reload]
       action :create
     end
   else
     template "/etc/monit/conf.d/#{params[:name]}.conf" do
       action :delete
-      notifies :restart, resources(:service => "monit"), params[:reload]
+      notifies :reload, resources(:service => "monit"), params[:reload]
     end
   end
 end

--- a/files/default/init-monit-ubuntu12.sh
+++ b/files/default/init-monit-ubuntu12.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ### BEGIN INIT INFO
 # Provides:          monit

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,9 +10,9 @@ if platform?("ubuntu")
 end
 
 service "monit" do
-  action [:enable, :start]
+  action [:enable, :reload]
   enabled true
-  supports [:start, :restart, :stop]
+  supports [:start, :reload, :restart, :stop]
 end
 
 directory "/etc/monit/conf.d/" do
@@ -28,5 +28,5 @@ template "/etc/monit/monitrc" do
   group "root"
   mode 0700
   source 'monitrc.erb'
-  notifies :restart, resources(:service => "monit"), :delayed
+  notifies :reload, resources(:service => "monit"), :delayed
 end


### PR DESCRIPTION
Hi,

Two changes are in this pull. We had made this fork a while ago, so I'm happy to update / rebase if need be. However, I wanted to see if this would be friendly before I do.

a) We updated the config updates to cause a reload rather than restart, for performance reasons. This should be fine, and I would think is preferable, but let me know if you disagree.

b) Ubuntu's default shell isn't bash (see discussion on that commit). The best practice should be to use `/usr/bin/env` to find the bash location.

Any concerns/ comments?
