### PR TITLE
Update Ubuntu default script.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,7 @@
 default[:monit][:notify_email]          = "notify@example.com"
 
+default[:monit][:alert][:not_on]        = "action, instance, pid, ppid"
+
 default[:monit][:logfile]               = 'syslog facility log_daemon'
 
 default[:monit][:poll_period]           = 60

--- a/files/ubuntu/monit.default
+++ b/files/ubuntu/monit.default
@@ -1,11 +1,10 @@
-# Defaults for monit initscript
-# sourced by /etc/init.d/monit
-# installed at /etc/default/monit by chef
+# /etc/default/monit
 
-# You must set this variable to for monit to start
-startup=1
+# Defaults for monit initscript.  This file is sourced by
+# /bin/sh from /etc/init.d/monit.
 
-# To change the intervals which monit should run,
-# edit the configuration file /etc/monit/monitrc
-# It can no longer be configured here.
+# Set START to yes to start the monit
+START=yes
 
+# Options to pass to monit
+#MONIT_OPTS=

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "apsoto@gmail.com"
 license          "MIT"
 description      "Configures monit.  Originally based off the 37 Signals Cookbook."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.7.3"
+version          "0.7.4"
 
 
 attribute 'monit/notify_email', 

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -29,7 +29,7 @@ set mail-format {
   message: <%= @node[:monit][:mail_format][:message] %>
 }
 
-set alert <%= @node[:monit][:notify_email] %><% if @node[:monit][:alert][:not_on] %> NOT ON { <%= @node[:monit][:alert][:not_on] %> }<% end %>
+set alert <%= @node[:monit][:notify_email] %><% if @node[:monit][:alert][:not_on] && @node[:monit][:alert][:not_on] != "" %> NOT ON { <%= @node[:monit][:alert][:not_on] %> }<% end %>
 
 set httpd port <%= @node[:monit][:port] %>
   <%= "use address #{@node[:monit][:address]}" if @node[:monit][:address] %>

--- a/templates/default/monitrc.erb
+++ b/templates/default/monitrc.erb
@@ -29,7 +29,7 @@ set mail-format {
   message: <%= @node[:monit][:mail_format][:message] %>
 }
 
-set alert <%= @node[:monit][:notify_email] %> NOT ON { action, instance, pid, ppid }
+set alert <%= @node[:monit][:notify_email] %><% if @node[:monit][:alert][:not_on] %> NOT ON { <%= @node[:monit][:alert][:not_on] %> }<% end %>
 
 set httpd port <%= @node[:monit][:port] %>
   <%= "use address #{@node[:monit][:address]}" if @node[:monit][:address] %>


### PR DESCRIPTION
Update the `monit.default` to work with the new version of monit/Ubuntu.
