### PR TITLE
template requires specifying source and cookbook to be found

### DIFF
--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -17,7 +17,7 @@ define :monitrc, :action => :enable, :reload => :delayed, :variables => {}, :tem
       action :create
     end
   else
-    template "/etc/monit/conf.d/#{params[:name]}.conf" do
+    file "/etc/monit/conf.d/#{params[:name]}.conf" do
       action :delete
       notifies :restart, resources(:service => "monit"), params[:reload]
     end


### PR DESCRIPTION
when using a wrapper cookbook and a custom template, if chef is unable to resolve the template source, it will throw a `Chef::Exceptions::FileNotFound`, even for delete actions.
