### PR TITLE
Refactor monit default into version specific files

### DIFF
--- a/files/ubuntu-12.04/monit.default
+++ b/files/ubuntu-12.04/monit.default
@@ -3,7 +3,7 @@
 # installed at /etc/default/monit by chef
 
 # You must set this variable to for monit to start
-START=yes
+startup=1
 
 # To change the intervals which monit should run,
 # edit the configuration file /etc/monit/monitrc


### PR DESCRIPTION
remove previous startup flag startup=1 since it is specific to older versions of monit. Add 12.04 LTS specific file which uses startup=1. For Issue #54
