### PR TITLE
Add reload action to service resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp/
+Berksfile.lock

--- a/definitions/monitrc.rb
+++ b/definitions/monitrc.rb
@@ -13,13 +13,13 @@ define :monitrc, :action => :enable, :reload => :delayed, :variables => {}, :tem
       source params[:template_source]
       cookbook params[:template_cookbook]
       variables params[:variables]
-      notifies :restart, "service[monit]", params[:reload]
+      notifies :reload, "service[monit]", params[:reload]
       action :create
     end
   else
     file "/etc/monit/conf.d/#{params[:name]}.conf" do
       action :delete
-      notifies :restart, "service[monit]", params[:reload]
+      notifies :reload, "service[monit]", params[:reload]
     end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,10 +22,10 @@ template "/etc/monit/monitrc" do
   group "root"
   mode 0700
   source 'monitrc.erb'
-  notifies :restart, "service[monit]", :delayed
+  notifies :reload, "service[monit]", :delayed
 end
 
 service "monit" do
   action [:enable, :start]
-  supports [:start, :restart, :stop]
+  supports [:start, :restart, :reload, :stop]
 end


### PR DESCRIPTION
This change adds `:reload` action support to the `monit` service, and is employed in a number of resources that would normally trigger a restart of the service.
