### PR TITLE
Parameterizing config file template name and source cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,3 +35,6 @@ default["monit"]["ssh_port"] = 22
 default["monit"]["eventqueue"]["set"] = true
 default["monit"]["eventqueue"]["basedir"] = "/var/monit"
 default["monit"]["eventqueue"]["slots"] = 1000
+
+default["monit"]["config_template_cookbook"] = "monit"
+default["monit"]["config_template"] = "monitrc.erb"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,8 @@ template "/etc/monit/monitrc" do
   owner "root"
   group "root"
   mode 0700
-  source 'monitrc.erb'
+  cookbook node['monit']['config_template_cookbook']
+  source node['monit']['config_template']
   notifies :restart, "service[monit]", :delayed
 end
 


### PR DESCRIPTION
This is to use hard-corded custom config file as template in other cookbook.
